### PR TITLE
Mount local ssh folder in dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -65,5 +65,8 @@
 		}
 	},
 	"postCreateCommand": "poetry install --with dev",
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+	"mounts": [
+		"source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
+	]
 }


### PR DESCRIPTION
Mount user's  `~/.ssh` folder in dev container to ensure public keys are inherited and git remote can be accessed