### PR TITLE
Fix missing checkout in cache cleanup

### DIFF
--- a/.github/workflows/cleanup_cache.yml
+++ b/.github/workflows/cleanup_cache.yml
@@ -1,10 +1,8 @@
 name: Cleanup cache
 on:
-  # pull_request:
-  #   types:
-  #     - closed
   pull_request:
-    branches: [ "develop" ]
+    types:
+      - closed
 
 jobs:
   cleanup:

--- a/.github/workflows/cleanup_cache.yml
+++ b/.github/workflows/cleanup_cache.yml
@@ -1,13 +1,18 @@
 name: Cleanup cache
 on:
+  # pull_request:
+  #   types:
+  #     - closed
   pull_request:
-    types:
-      - closed
+    branches: [ "develop" ]
 
 jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
       - name: Cleanup
         run: |
           gh extension install actions/gh-actions-cache


### PR DESCRIPTION
`actions/checkout` was missing in cache cleanup job