### PR TITLE
Enable poetry cache in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,12 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      
+      - name: Mount Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/cache/poetry
+          key: poetry-{{ hashFiles('poetry.lock') }}
 
       -
         name: Linting
@@ -26,6 +32,7 @@ jobs:
           target: lint
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-contexts: poetry_cache=~/cache/poetry
       
       -
         name: Testing
@@ -36,6 +43,7 @@ jobs:
           target: test
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-contexts: poetry_cache=~/cache/poetry
 
       -
         name: Format checking
@@ -46,3 +54,4 @@ jobs:
           target: format-check
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-contexts: poetry_cache=~/cache/poetry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,15 +16,17 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
-      # - name: Create cache directory
-      #   run: mkdir -p ${{ github.workspace }}/.cache/poetry
       
       - name: Mount cache
+        id: mount-cache
         uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/.cache/poetry
           key: poetry-{{ hashFiles('poetry.lock') }}
+      
+      - name: Create cache directory
+        if: steps.mount-cache.outputs.cache-hit != 'true'
+        run: mkdir -p ${{ github.workspace }}/.cache/poetry
 
       -
         name: Linting

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,11 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      - name: Create cache directory
+        run: mkdir -p ~/cache/poetry
       
-      - name: Mount Cache
+      - name: Mount cache
         uses: actions/cache@v3
         with:
           path: ~/cache/poetry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           path: ${{ github.workspace }}/.cache/poetry
           key: poetry-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            poetry-
       
       - name: Create cache directory
         if: steps.mount-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,11 @@ jobs:
           restore-keys: |
             poetry-
       
-      - name: Create cache directory
-        if: steps.mount-cache.outputs.cache-hit != 'true'
-        run: mkdir -p ${{ github.workspace }}/.cache/poetry
+      - name: Create cache directory and retrieve directory uid
+        id: create-cache-dir
+        run: |
+          mkdir -p ${{ github.workspace }}/.cache/poetry
+          echo "uid=$(id -u $(stat -c "%U" ${{ github.workspace }}/.cache/poetry))" >> $GITHUB_OUTPUT
 
       -
         name: Linting
@@ -40,6 +42,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-contexts: poetry_cache=${{ github.workspace }}/.cache/poetry
+          build-args: UID=${{ steps.create-cache-dir.outputs.uid }}
       
       -
         name: Testing
@@ -51,6 +54,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-contexts: poetry_cache=${{ github.workspace }}/.cache/poetry
+          build-args: UID=${{ steps.create-cache-dir.outputs.uid }}
 
       -
         name: Format checking
@@ -62,6 +66,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-contexts: poetry_cache=${{ github.workspace }}/.cache/poetry
+          build-args: UID=${{ steps.create-cache-dir.outputs.uid }}
       
       - name: List files in cache
         run: find ${{ github.workspace }}/.cache/poetry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,3 +62,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-contexts: poetry_cache=${{ github.workspace }}/.cache/poetry
+      
+      - name: List files in cache
+        run: find ${{ github.workspace }}/.cache/poetry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,13 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Create cache directory
-        run: mkdir -p ~/cache/poetry
+      # - name: Create cache directory
+      #   run: mkdir -p ${{ github.workspace }}/.cache/poetry
       
       - name: Mount cache
         uses: actions/cache@v3
         with:
-          path: ~/cache/poetry
+          path: ${{ github.workspace }}/.cache/poetry
           key: poetry-{{ hashFiles('poetry.lock') }}
 
       -
@@ -35,7 +35,7 @@ jobs:
           target: lint
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-contexts: poetry_cache=~/cache/poetry
+          build-contexts: poetry_cache=${{ github.workspace }}/.cache/poetry
       
       -
         name: Testing
@@ -46,7 +46,7 @@ jobs:
           target: test
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-contexts: poetry_cache=~/cache/poetry
+          build-contexts: poetry_cache=${{ github.workspace }}/.cache/poetry
 
       -
         name: Format checking
@@ -57,4 +57,4 @@ jobs:
           target: format-check
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-contexts: poetry_cache=~/cache/poetry
+          build-contexts: poetry_cache=${{ github.workspace }}/.cache/poetry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/.cache/poetry
-          key: poetry-{{ hashFiles('poetry.lock') }}
+          key: poetry-${{ hashFiles('poetry.lock') }}
       
       - name: Create cache directory
         if: steps.mount-cache.outputs.cache-hit != 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,14 @@ WORKDIR /home/app
 RUN touch README.md
 RUN touch aprova
 COPY --chown=app pyproject.toml poetry.lock ./
-RUN --mount=type=bind,target=${POETRY_CACHE_DIR},uid=${UID},from=poetry_cache poetry install --no-root
+RUN --mount=type=bind,target=${POETRY_CACHE_DIR},from=poetry_cache poetry install --no-root
 
 FROM builder AS ci-env
 
 ENV PATH="/home/app/.venv/bin:$PATH"
 COPY --chown=app .ci .ci
 
-RUN --mount=type=bind,target=${POETRY_CACHE_DIR},uid=${UID},from=poetry_cache poetry install --with dev --no-root
+RUN --mount=type=bind,target=${POETRY_CACHE_DIR},from=poetry_cache poetry install --with dev --no-root
 COPY --chown=app src src
 COPY --chown=app tests tests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /home/app
 
 # create virtual environment and install dependencies
 RUN touch README.md
-RUN touch prova
+RUN touch provaa
 COPY --chown=app pyproject.toml poetry.lock ./
 RUN --mount=type=cache,target=${POETRY_CACHE_DIR},uid=${UID},from=poetry_cache poetry install --no-root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ WORKDIR /home/app
 
 # create virtual environment and install dependencies
 RUN touch README.md
+RUN touch prova
 COPY --chown=app pyproject.toml poetry.lock ./
 RUN --mount=type=cache,target=${POETRY_CACHE_DIR},uid=${UID},from=poetry_cache poetry install --no-root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,16 +20,16 @@ WORKDIR /home/app
 
 # create virtual environment and install dependencies
 RUN touch README.md
-RUN touch provaaaa
+RUN touch aprova
 COPY --chown=app pyproject.toml poetry.lock ./
-RUN --mount=type=cache,target=${POETRY_CACHE_DIR},uid=${UID},from=poetry_cache poetry install --no-root
+RUN --mount=type=bind,target=${POETRY_CACHE_DIR},uid=${UID},from=poetry_cache poetry install --no-root
 
 FROM builder AS ci-env
 
 ENV PATH="/home/app/.venv/bin:$PATH"
 COPY --chown=app .ci .ci
 
-RUN --mount=type=cache,target=${POETRY_CACHE_DIR},uid=${UID},from=poetry_cache poetry install --with dev --no-root
+RUN --mount=type=bind,target=${POETRY_CACHE_DIR},uid=${UID},from=poetry_cache poetry install --with dev --no-root
 COPY --chown=app src src
 COPY --chown=app tests tests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /home/app
 
 # create virtual environment and install dependencies
 RUN touch README.md
-RUN touch provaa
+RUN touch provaaaa
 COPY --chown=app pyproject.toml poetry.lock ./
 RUN --mount=type=cache,target=${POETRY_CACHE_DIR},uid=${UID},from=poetry_cache poetry install --no-root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,14 @@ WORKDIR /home/app
 # create virtual environment and install dependencies
 RUN touch README.md
 COPY --chown=app pyproject.toml poetry.lock ./
-RUN --mount=type=cache,target=${POETRY_CACHE_DIR},uid=${UID} poetry install --no-root
+RUN --mount=type=cache,target=${POETRY_CACHE_DIR},uid=${UID},from=poetry_cache poetry install --no-root
 
 FROM builder AS ci-env
 
 ENV PATH="/home/app/.venv/bin:$PATH"
 COPY --chown=app .ci .ci
 
-RUN --mount=type=cache,target=${POETRY_CACHE_DIR},uid=${UID} poetry install --with dev --no-root
+RUN --mount=type=cache,target=${POETRY_CACHE_DIR},uid=${UID},from=poetry_cache poetry install --with dev --no-root
 COPY --chown=app src src
 COPY --chown=app tests tests
 


### PR DESCRIPTION
When docker layers are not found in the cache, `poetry install` gets executed again, downloading all packages each time. Making sure that poetry looks up packages in the cache would speed up re-building of those layers.